### PR TITLE
Add [mongo.ssl.host.allow.non.matching] option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'com.github.ben-manes.versions'
 
 ext.configDir = new File(rootDir, 'config')
 ext.hadoopBinaries = "${rootDir}/hadoop-binaries".toString()
-ext.javaDriverVersion = '3.2.1'
+ext.javaDriverVersion = '3.4.2'
 ext.hiveVersion = '1.2.1'
 ext.pigVersion = '0.15.0'
 ext.hadoopVersion = '1.2.1'

--- a/core/src/main/java/com/mongodb/hadoop/input/MongoInputSplit.java
+++ b/core/src/main/java/com/mongodb/hadoop/input/MongoInputSplit.java
@@ -86,6 +86,7 @@ public class MongoInputSplit extends InputSplit implements Writable, org.apache.
         setQuery(MongoConfigUtil.getQuery(conf));
         setSort(MongoConfigUtil.getSort(conf));
         setLimit(MongoConfigUtil.getLimit(conf));
+        MongoConfigUtil.isAllowNonMatchingSslHost(conf);
     }
 
     public void setInputURI(final MongoClientURI inputURI) {


### PR DESCRIPTION
 if we don't want to check host name in certificate matches remote host (for example in case of port forwarding)